### PR TITLE
fix: incorrect time displayed because of user timezone

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,23 +1,53 @@
-import React from "react";
-import { Routes, Route } from "react-router-dom";
-import { Flex, Text } from "@chakra-ui/core";
-
-import Launches from "./launches";
-import Launch from "./launch";
-import Home from "./home";
-import LaunchPads from "./launch-pads";
-import LaunchPad from "./launch-pad";
+import React, { useEffect }       from "react";
+import { Routes, Route }          from "react-router-dom";
+import { Flex, Text }             from "@chakra-ui/core";
+import Launches                   from "./launches";
+import Launch                     from "./launch";
+import Home                       from "./home";
+import LaunchPads                 from "./launch-pads";
+import LaunchPad                  from "./launch-pad";
+import { useSpaceX }              from "../utils/use-space-x";
+import { getTimezonesBySiteName } from "../utils/getTImezonesBySiteName";
 
 export default function App() {
+  const { data } = useSpaceX(
+    "/launchpads",
+  );
+
+  useEffect(() => {
+    const getter = async () => {
+      if (data) {
+        const timezonesBySiteName = await getTimezonesBySiteName(data)
+        console.log("timezonesBySiteName", timezonesBySiteName)
+      }
+    }
+    getter()
+  }, [data])
+
   return (
     <div>
       <NavBar />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/launches" element={<Launches />} />
-        <Route path="/launches/:launchId" element={<Launch />} />
-        <Route path="/launch-pads" element={<LaunchPads />} />
-        <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
+        <Route
+          path="/"
+          element={<Home />}
+        />
+        <Route
+          path="/launches"
+          element={<Launches />}
+        />
+        <Route
+          path="/launches/:launchId"
+          element={<Launch />}
+        />
+        <Route
+          path="/launch-pads"
+          element={<LaunchPads />}
+        />
+        <Route
+          path="/launch-pads/:launchPadId"
+          element={<LaunchPad />}
+        />
       </Routes>
     </div>
   );

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -1,6 +1,6 @@
-import React from "react";
-import { useParams, Link as RouterLink } from "react-router-dom";
-import { format as timeAgo } from "timeago.js";
+import React                                 from "react";
+import { useParams, Link as RouterLink }     from "react-router-dom";
+import { format as timeAgo }                 from "timeago.js";
 import { Watch, MapPin, Navigation, Layers } from "react-feather";
 import {
   Flex,
@@ -19,12 +19,14 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
-} from "@chakra-ui/core";
+  Tooltip
+}                                            from "@chakra-ui/core";
 
-import { useSpaceX } from "../utils/use-space-x";
+import { useSpaceX }      from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
-import Error from "./error";
-import Breadcrumbs from "./breadcrumbs";
+import Error              from "./error";
+import Breadcrumbs        from "./breadcrumbs";
+
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -33,7 +35,11 @@ export default function Launch() {
   if (error) return <Error />;
   if (!launch) {
     return (
-      <Flex justifyContent="center" alignItems="center" minHeight="50vh">
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        minHeight="50vh"
+      >
         <Spinner size="lg" />
       </Flex>
     );
@@ -52,7 +58,11 @@ export default function Launch() {
       <Box m={[3, 6]}>
         <TimeAndLocation launch={launch} />
         <RocketInfo launch={launch} />
-        <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
+        <Text
+          color="gray.700"
+          fontSize={["md", null, "lg"]}
+          my="8"
+        >
           {launch.details}
         </Text>
         <Video launch={launch} />
@@ -95,16 +105,28 @@ function Header({ launch }) {
       >
         {launch.mission_name}
       </Heading>
-      <Stack isInline spacing="3">
-        <Badge variantColor="purple" fontSize={["xs", "md"]}>
+      <Stack
+        isInline
+        spacing="3"
+      >
+        <Badge
+          variantColor="purple"
+          fontSize={["xs", "md"]}
+        >
           #{launch.flight_number}
         </Badge>
         {launch.launch_success ? (
-          <Badge variantColor="green" fontSize={["xs", "md"]}>
+          <Badge
+            variantColor="green"
+            fontSize={["xs", "md"]}
+          >
             Successful
           </Badge>
         ) : (
-          <Badge variantColor="red" fontSize={["xs", "md"]}>
+          <Badge
+            variantColor="red"
+            fontSize={["xs", "md"]}
+          >
             Failed
           </Badge>
         )}
@@ -114,24 +136,55 @@ function Header({ launch }) {
 }
 
 function TimeAndLocation({ launch }) {
+
   return (
-    <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
+    <SimpleGrid
+      columns={[1, 1, 2]}
+      borderWidth="1px"
+      p="4"
+      borderRadius="md"
+    >
       <Stat>
         <StatLabel display="flex">
-          <Box as={Watch} width="1em" />{" "}
-          <Box ml="2" as="span">
+          <Box
+            as={Watch}
+            width="1em"
+          />{" "}
+          <Box
+            ml="2"
+            as="span"
+          >
             Launch Date
           </Box>
         </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
-        </StatNumber>
+
+
+        <Tooltip
+          label={formatDateTime(launch.launch_date_local)}
+          placement="bottom"
+          aria-label="A tooltip"
+
+        >
+          <Box>
+            <StatNumber fontSize={["md", "xl"]}>
+              {formatDateTime(launch.launch_date_local, launch.launch_site.site_name)}
+            </StatNumber>
+          </Box>
+        </Tooltip>
+
+
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>
       <Stat>
         <StatLabel display="flex">
-          <Box as={MapPin} width="1em" />{" "}
-          <Box ml="2" as="span">
+          <Box
+            as={MapPin}
+            width="1em"
+          />{" "}
+          <Box
+            ml="2"
+            as="span"
+          >
             Launch Site
           </Box>
         </StatLabel>
@@ -162,8 +215,14 @@ function RocketInfo({ launch }) {
     >
       <Stat>
         <StatLabel display="flex">
-          <Box as={Navigation} width="1em" />{" "}
-          <Box ml="2" as="span">
+          <Box
+            as={Navigation}
+            width="1em"
+          />{" "}
+          <Box
+            ml="2"
+            as="span"
+          >
             Rocket
           </Box>
         </StatLabel>
@@ -175,8 +234,14 @@ function RocketInfo({ launch }) {
       <StatGroup>
         <Stat>
           <StatLabel display="flex">
-            <Box as={Layers} width="1em" />{" "}
-            <Box ml="2" as="span">
+            <Box
+              as={Layers}
+              width="1em"
+            />{" "}
+            <Box
+              ml="2"
+              as="span"
+            >
               First Stage
             </Box>
           </StatLabel>
@@ -193,8 +258,14 @@ function RocketInfo({ launch }) {
         </Stat>
         <Stat>
           <StatLabel display="flex">
-            <Box as={Layers} width="1em" />{" "}
-            <Box ml="2" as="span">
+            <Box
+              as={Layers}
+              width="1em"
+            />{" "}
+            <Box
+              ml="2"
+              as="span"
+            >
               Second Stage
             </Box>
           </StatLabel>
@@ -215,7 +286,10 @@ function RocketInfo({ launch }) {
 
 function Video({ launch }) {
   return (
-    <AspectRatioBox maxH="400px" ratio={1.7}>
+    <AspectRatioBox
+      maxH="400px"
+      ratio={1.7}
+    >
       <Box
         as="iframe"
         title={launch.mission_name}
@@ -228,9 +302,16 @@ function Video({ launch }) {
 
 function Gallery({ images }) {
   return (
-    <SimpleGrid my="6" minChildWidth="350px" spacing="4">
+    <SimpleGrid
+      my="6"
+      minChildWidth="350px"
+      spacing="4"
+    >
       {images.map((image) => (
-        <a href={image} key={image}>
+        <a
+          href={image}
+          key={image}
+        >
           <Image src={image.replace("_o.jpg", "_z.jpg")} />
         </a>
       ))}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,5 +1,35 @@
+
+const timezonesBySiteName = {
+  "VAFB SLC 3W": {
+    "timeZoneId": "America/Los_Angeles",
+    "timeZoneName": "Pacific Standard Time"
+  },
+  "CCAFS SLC 40": {
+    "timeZoneId": "America/New_York",
+    "timeZoneName": "Eastern Standard Time"
+  },
+  "STLS": {
+    "timeZoneId": "America/Chicago",
+    "timeZoneName": "Central Standard Time"
+  },
+  "Kwajalein Atoll": {
+    "timeZoneId": "Pacific/Majuro",
+    "timeZoneName": "Marshall Islands Time"
+  },
+  "VAFB SLC 4E": {
+    "timeZoneId": "America/Los_Angeles",
+    "timeZoneName": "Pacific Standard Time"
+  },
+  "KSC LC 39A": {
+    "timeZoneId": "America/New_York",
+    "timeZoneName": "Eastern Standard Time"
+  }
+}
+
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
+
     weekday: "long",
     year: "numeric",
     month: "long",
@@ -7,14 +37,17 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
+export function formatDateTime(timestamp, siteName) {
+
   return new Intl.DateTimeFormat("en-US", {
+
+    timeZone: siteName ? timezonesBySiteName[siteName]?.timeZoneId : Intl.DateTimeFormat().resolvedOptions().timeZone,
     year: "numeric",
     month: "long",
     day: "numeric",
     hour: "numeric",
     minute: "numeric",
     second: "numeric",
-    timeZoneName: "short",
+    timeZoneName: "long",
   }).format(new Date(timestamp));
 }

--- a/src/utils/getTImezonesBySiteName.js
+++ b/src/utils/getTImezonesBySiteName.js
@@ -1,0 +1,28 @@
+const googleApiKey = process.env.REACT_APP_GOOGLE_API_KEY
+
+export const getTimezonesBySiteName = async (launchPads) => {
+
+  const responses = await Promise.all(launchPads.map(async launchPad => {
+    const singleResponse = await fetch(`https://maps.googleapis.com/maps/api/timezone/json?location=${launchPad.location?.latitude.toString()},${launchPad.location?.longitude.toString()}&timestamp=1331161200&key=${googleApiKey}`)
+    const { timeZoneId, timeZoneName } = await singleResponse.json()
+
+    return {
+      name: launchPad.name,
+      timeZoneId,
+      timeZoneName
+    }
+  }))
+
+  const result = responses.reduce((acc, current) => {
+    const { name, timeZoneId, timeZoneName } = current
+    return {
+      ...acc,
+      [name]: {
+        timeZoneId,
+        timeZoneName
+      }
+    }
+  }, {})
+
+  return result
+}


### PR DESCRIPTION
I understand that Moment should be able to solve this problem as well, but I decided to try a "lighter" solution.

Since launch pads seem to be quite static piece of data, I have decided to just pull them and get their timezones from google and hardcode timezonesBySiteName for quick solution of this test case.
Should that be a production app or if lanuch pads were more dynamic content, I would probably add a context wrapper to store the result of the getTimezonesBySiteName function.

To test the getTimezonesBySiteName you need to add your REACT_APP_GOOGLE_API_KEY to .env file.

Also for production I would probably question whether the tooltip is a good solution to show the second date. Especially on mobile devices.